### PR TITLE
Fix duplicate folder icons in Sublime Text Build 3065

### DIFF
--- a/Numix.sublime-theme
+++ b/Numix.sublime-theme
@@ -1187,5 +1187,18 @@
     "class": "icon_highlight",
     "parents": [{"class": "icon_button_control", "attributes": ["hover"]}],
     "layer0.tint": [255, 255, 255]
+  },
+  //Hide double folders
+  {
+    "class": "icon_file_type",
+    "content_margin": [0,0]
+  },
+  {
+    "class": "icon_folder",
+    "content_margin": [0,0]
+  },
+  {
+    "class": "icon_folder_loading",
+    "content_margin": [0,0]
   }
 ]


### PR DESCRIPTION
This prevents duplicate folder icons from showing in Sublime Text Build 3065.

![screen shot 2014-10-18 at 16 07 31](https://cloud.githubusercontent.com/assets/2728159/4690071/878e6790-56d8-11e4-9e95-50c4b5c1d774.png)

See https://github.com/itsthatguy/theme-itg-flat/issues/38 for more info
